### PR TITLE
replaced a word

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
 			<li><a href="https://www.facebook.com/colin.li.946/"> Facebook</a></li>
 			<li><a href="https://github.com/G00dNoodle"> Github</a></li>
 			<li><a href="https://steamcommunity.com/profiles/76561198064339611/"> Steam</a></li>
-			<li><a href="https://www.linkedin.com/in/colin-li-2806a6158/"> Youtube</a></li>
+			<li><a href="https://www.linkedin.com/in/colin-li-2806a6158/">Linkedin</a></li>
 		</ul>
 
 	</footer>


### PR DESCRIPTION
I replaced the old youtube placeholder that I missed in the previous commit to change it to "LinkedIn" in the footer